### PR TITLE
Build commit message from tickets by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,15 @@ Prr provides command line assistance when merging Joyent pull requests on GitHub
 ## Usage
 
 ```
-./bin/prr -h
-Usage: prr [-C GITREPO] [-v] <pull request number>
+$ ./bin/prr -h
+Usage: prr [options] <pull request number>
+options:
+    -h, --help               Print this help and exit.
+    -C ARG, --gitrepo=ARG    A path to the local git repository to act upon.
+    -M, --allCommitMessages  Use all lines of the commit messages from the PR in
+                             the summary, rather than just those with jira
+                             tickets.
+    -v, --verbose            Verbose output.
 ```
 
 When run from the top-level of a GitHub repository with a pull request number
@@ -35,6 +42,10 @@ in that repository, but merely uses the `.git/config` file in that repository
 to lookup the remote `origin` in order to construct the correct URLs when
 making GitHub REST API calls.
 
+If `-M` is passed, all commit messages from the PR are written to the temporary
+file, otherwise only messages which match the regular expression
+`'^[A-Z]+-[0-9]+ '` (e.g. "`JIRA-1234 this is a ticket synopsis`") are included.
+
 Note that prr enforces only a single approver for any given pull request.
 
 ## Configuration
@@ -52,7 +63,8 @@ looks like this:
     "userEmail": {
         "anonreviewer1": "foo.bar@email.com",
         "anonreviewer2": "bar.baz@email.com"
-    }
+    },
+    "allCommitMessages": false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ options:
     -h, --help               Print this help and exit.
     -C ARG, --gitrepo=ARG    A path to the local git repository to act upon.
     -M, --allCommitMessages  Use all lines of the commit messages from the PR in
-                             the summary, rather than just those with jira
-                             tickets.
+                             the summary, rather than just those with tickets.
     -v, --verbose            Verbose output.
 ```
 
@@ -43,8 +42,7 @@ to lookup the remote `origin` in order to construct the correct URLs when
 making GitHub REST API calls.
 
 If `-M` is passed, all commit messages from the PR are written to the temporary
-file, otherwise only messages which match the regular expression
-`'^[A-Z]+-[0-9]+ '` (e.g. "`JIRA-1234 this is a ticket synopsis`") are included.
+file, otherwise only messages which are ticket id/synopses are included.
 
 Note that prr enforces only a single approver for any given pull request.
 

--- a/lib/prr.js
+++ b/lib/prr.js
@@ -258,6 +258,10 @@ function gatherPullRequestProps(args, cb) {
  * @param {String} args.gitRepo - The github "username/repo" string.
  * @param {String} args.tickets - any existing ticket information we have.
  * @param {String} args.prNumber - the number of the beast^Wcommit message
+ * @param {Boolean} args.allCommitMessages - add all commit message lines from
+ *                                  the PR to the list of messages, rather than
+ *                                  just the ones which appear to be
+ *                                  ticket/synopsis pairs
  * @param {Function} cb - `function (err, lastCommit, ticketInfo, messages)`
  */
 function gatherPullRequestCommits(args, cb) {
@@ -265,6 +269,7 @@ function gatherPullRequestCommits(args, cb) {
     assert.object(args.tickets, 'args.tickets');
     assert.string(args.prNumber, 'args.prNumber');
     assert.string(args.gitRepo, 'args.gitRepo');
+    assert.bool(args.allCommitMessages, 'args.allCommitMessages');
 
     assert.func(cb, 'cb');
     gitClient.get(format(
@@ -285,7 +290,7 @@ function gatherPullRequestCommits(args, cb) {
                         // record the jira ticket and full line
                         tickets[line.split(' ')[0]] = line.trim();
                         messages.push(line.trim());
-                    } else {
+                    } else if (args.allCommitMessages) {
                         messages.push(line.trim());
                     }
                 });
@@ -321,7 +326,7 @@ function gatherReviewerUsernames(args, cb) {
             // we don't have a format Set object, so make do with this
             var reviewers = {};
             reviews.forEach(function processReview(obj, index) {
-                if (obj.user.login !== submitter) {
+                if (obj.user.login !== args.submitter) {
                     reviewers[obj.user.login] = true;
                 }
             });
@@ -770,16 +775,20 @@ function squashMerge(args, cb) {
     );
 }
 
-function usage() {
-    console.log('Usage: prr [-C GITREPO] [-v] <pull request number>');
+function usage(parser) {
+    var help = parser.help({includeEnv: true}).trimRight();
+    console.log('Usage: prr [options] <pull request number>\n'
+                + 'options:\n'
+                + help);
     process.exit(2);
 }
 
 // main
 
 // Specify the options. Minimally `name` (or `names`) and `type`
-// must be given for each.
-var cli_options = [
+// must be given for each. Note that cliOptions long-names should be
+// kept in sync with defaultOptions and the values in ~/.prrconfig
+var cliOptions = [
     {
         // `names` or a single `name`. First element is the `opts.KEY`.
         names: ['help', 'h'],
@@ -793,14 +802,20 @@ var cli_options = [
         help: 'A path to the local git repository to act upon.'
     },
     {
+        names: ['allCommitMessages', 'M'],
+        type: 'bool',
+        help: 'Use all lines of the commit messages from the PR in the ' +
+            'summary, rather than just those with jira tickets'
+    },
+    {
         names: ['verbose', 'v'],
         type: 'arrayOfBool',
-        help: 'Verbose output. Use multiple times for more verbose.'
+        help: 'Verbose output.'
     },
 ];
 
 var context = {};
-var parser = dashdash.createParser({options: cli_options});
+var parser = dashdash.createParser({options: cliOptions});
 try {
     var opts = parser.parse(process.argv);
 
@@ -808,14 +823,17 @@ try {
         log.level(bunyan.DEBUG);
     }
     if (opts.help) {
-        usage();
+        usage(parser);
     }
     if (opts._args.length !== 1) {
         console.log('Error: missing pr number');
-        usage();
+        usage(parser);
     }
     if (opts.gitrepo) {
         context.repoPath = expandTilde(opts.gitrepo);
+    }
+    if (opts.allCommitMessages) {
+        context.allCommitMessages = opts.allCommitMessages;
     }
     context.prNumber = opts._args[0];
 } catch (e) {
@@ -823,14 +841,21 @@ try {
     process.exit(1);
 }
 
-// Use `parser.help()` for formatted options help.
-if (opts.help) {
-    var help = parser.help({includeEnv: true}).trimRight();
-    console.log('usage: node foo.js [OPTIONS]\n'
-                + 'options:\n'
-                + help);
-    process.exit(0);
-}
+// Set defaults for values not passed from the CLI. Iterate over a set of
+// variableName: default value pairs and add them to our context.
+var defaultOptions = {
+    'allCommitMessages': false
+};
+Object.keys(defaultOptions).forEach(function(item) {
+    var defaultVal = defaultOptions[item];
+    if (context[item] === undefined) {
+        if (PRR_CONFIG[item] !== undefined) {
+            context[item] = PRR_CONFIG[item];
+        } else {
+            context[item] = defaultVal;
+        }
+    }
+});
 
 mod_vasync.pipeline({
     arg: context,

--- a/lib/prr.js
+++ b/lib/prr.js
@@ -271,29 +271,11 @@ function gatherPullRequestCommits(args, cb) {
     gitClient.get(format(
         '/repos/%s/pulls/%s/commits', args.gitRepo, args.prNumber),
         function getPr(err, req, res, commits) {
-            if (err !== null) {
-                console.log(format('Unable to gather commits for %s#%s',
-                    arg.gitRepo, arg.prNumber));
-                cb(err);
-                return;
-            }
-            var tickets = args.tickets;
-            var messages = [];
-            var lastCommit;
-            commits.forEach(function processCommit(obj, index) {
-                var lines = obj.commit.message.split('\n');
-                lastCommit = obj.sha;
-                lines.forEach(function extractTickets(line) {
-                    if (TICKET_RE.test(line)) {
-                        // record the jira ticket and full line
-                        tickets[line.split(' ')[0]] = line.trim();
-                        messages.push(line.trim());
-                    } else if (args.allCommitMessages) {
-                        messages.push(line.trim());
-                    }
-                });
-            });
-            cb(null, lastCommit, tickets, messages);
+        if (err !== null) {
+            console.log(format('Unable to gather commits for %s#%s',
+                arg.gitRepo, arg.prNumber));
+            cb(err);
+            return;
         }
 
         var messages = [];
@@ -305,7 +287,7 @@ function gatherPullRequestCommits(args, cb) {
                     // record the jira ticket and full line
                     args.tickets[line.split(' ')[0]] = line.trim();
                     messages.push(line.trim());
-                } else {
+                } else if (args.allCommitMessages) {
                     messages.push(line.trim());
                 }
             });

--- a/lib/prr.js
+++ b/lib/prr.js
@@ -57,8 +57,11 @@ var gitClient = restifyClients.createJsonClient({
 var submitter = null;
 var prNumber = null;
 
-// match JIRA-format ticket names, expected at the beginning of the line
+// match JIRA format ticket names, for example, 'FOO-123 '
 var TICKET_RE = new RegExp('^[A-Z]+-[0-9]+ ');
+// match GitHub format ticket names, for example 'owner/repo#1234 '
+// we allow alphanumeric chars, hyphens and underscores
+var GITHUB_TICKET_RE = new RegExp('^[a-zA-Z0-9-_]+/[a-zA-Z0-9-_]+#[0-9]+ ');
 
 // Some joyent users don't have email addresses in their github profiles.
 // Fallback to this list instead. This gets loaded from ~/.prrconfig
@@ -240,7 +243,7 @@ function gatherPullRequestProps(args, cb) {
             var submitter = pr.user.login;
             var title = pr.title.trim();
             var state = pr.state;
-            if (TICKET_RE.test(title)) {
+            if (TICKET_RE.test(title) || GITHUB_TICKET_RE.test(title)) {
                 tickets[(title.split(' ')[0])] = pr.title;
             }
             cb(null, submitter, title, tickets, state);
@@ -283,7 +286,7 @@ function gatherPullRequestCommits(args, cb) {
         commits.forEach(function processCommit(obj, index) {
             var lines = obj.commit.message.split('\n');
             lines.forEach(function extractTickets(line) {
-                if (TICKET_RE.test(line)) {
+                if (TICKET_RE.test(line) || GITHUB_TICKET_RE.test(line)) {
                     // record the jira ticket and full line
                     args.tickets[line.split(' ')[0]] = line.trim();
                     messages.push(line.trim());

--- a/lib/prr.js
+++ b/lib/prr.js
@@ -783,6 +783,13 @@ function usage(parser) {
     process.exit(2);
 }
 
+function prrConfigDefault(key, defaultValue) {
+    if (PRR_CONFIG[key] !== undefined) {
+        return PRR_CONFIG[key];
+    }
+    return defaultValue;
+}
+
 // main
 
 // Specify the options. Minimally `name` (or `names`) and `type`
@@ -805,7 +812,8 @@ var cliOptions = [
         names: ['allCommitMessages', 'M'],
         type: 'bool',
         help: 'Use all lines of the commit messages from the PR in the ' +
-            'summary, rather than just those with jira tickets'
+            'summary, rather than just those with tickets',
+        default: prrConfigDefault('allCommitMessages', false)
     },
     {
         names: ['verbose', 'v'],
@@ -834,28 +842,14 @@ try {
     }
     if (opts.allCommitMessages) {
         context.allCommitMessages = opts.allCommitMessages;
+    } else {
+        context.allCommitMessages = false;
     }
     context.prNumber = opts._args[0];
 } catch (e) {
     console.error('prr: error: %s', e.message);
     process.exit(1);
 }
-
-// Set defaults for values not passed from the CLI. Iterate over a set of
-// variableName: default value pairs and add them to our context.
-var defaultOptions = {
-    'allCommitMessages': false
-};
-Object.keys(defaultOptions).forEach(function(item) {
-    var defaultVal = defaultOptions[item];
-    if (context[item] === undefined) {
-        if (PRR_CONFIG[item] !== undefined) {
-            context[item] = PRR_CONFIG[item];
-        } else {
-            context[item] = defaultVal;
-        }
-    }
-});
 
 mod_vasync.pipeline({
     arg: context,


### PR DESCRIPTION
This addresses ticket #8 and adds a '-M' command line option to use all message lines from all commits by default, or without -M, just use message lines that contain Jira tickets. The title of the PR is always included in the squashed commit message.

The default behaviour can be overridden by having `allCommitMessages` set to a boolean in ~/.prrconfig.

This pr also fixes a minor problem where any code review comments from the submitter caused `prr` to include their name in the list of reviewers by mistake.