### PR TITLE
Use terminal link support to link the files URL

### DIFF
--- a/lib/prr.js
+++ b/lib/prr.js
@@ -600,6 +600,13 @@ function readCommitMessage(args, cb) {
 }
 
 /*
+ * We don't make any attempt to check if the terminal can actually handle this.
+ */
+function linkify(link, text) {
+    return ('\x1B]8;;' + link + '\x1B\\' + text + '\x1B]8;;\x1B\\');
+}
+
+/*
  * Check if the user wants to go ahead with the merge, abort, or edit the commit
  * message.
  *
@@ -640,9 +647,11 @@ function getAnswer(args, cb) {
         console.log(commit.sha + ' ' + commit.commit.message.split('\n')[0]);
     });
 
+    var filesLink = format('https://github.com/%s/pull/%s/files', args.gitRepo,
+        args.prNumber);
+
     console.log('');
-    console.log(format('--- changes: https://github.com/%s/pull/%s/files ---',
-        args.gitRepo, args.prNumber));
+    console.log('--- changes: ' + linkify(filesLink, filesLink) + ' ---');
 
     if (Object.keys(args.tickets).length > 0) {
         console.log(format('--- tickets: %s ---',


### PR DESCRIPTION
This doesn't even try to figure out if the terminal can handle the escape
sequence, so it's possibly of limited use.