### PR TITLE
fix leading whitespace in commit message

### DIFF
--- a/lib/prr.js
+++ b/lib/prr.js
@@ -517,10 +517,14 @@ function writeCommitMessage(args, cb) {
 
         // Often, PR titles are the same as the first commit message line in
         // the PR. Try to catch these cases by removing the first message line
-        // if it's identical to the title.
+        // if it's identical to the title as well as any blank lines in between.
         if (args.messages.length > 0) {
             var remaining_messages = args.messages;
-            if (args.title === args.messages[0]) {
+            if (args.title === remaining_messages[0]) {
+                remaining_messages = remaining_messages.slice(1);
+            }
+
+            while (remaining_messages[0].trim() === '') {
                 remaining_messages = remaining_messages.slice(1);
             }
 


### PR DESCRIPTION
When using allCommitMessages option, and prr decides to strip the initial line,
it should also strip any blank lines in between, so the re-constructed commit
message is correct.

Signed-off-by: John Levon <john.levon@nutanix.com>